### PR TITLE
auto-patch: fix failure when patch directory exists but is empty...

### DIFF
--- a/auto-patch/auto-patch.bash.in
+++ b/auto-patch/auto-patch.bash.in
@@ -32,6 +32,10 @@ try_to_apply_patches()
         einfo "Check ${PATCH_DIR_FULL}"
     fi
     if [[ -d ${PATCH_DIR_FULL} ]] ; then
+		# activate nullglob if it isn't already
+		local saved_opt=$(shopt nullglob &> /dev/null && echo "yes" || echo "no")
+		[[ ${saved_opt} == no ]] && shopt -s nullglob
+
         cd "${S}" || die "Failed to cd into ${S}!"
         for i in "${PATCH_DIR_FULL}"/*.patch ; do
             if declare -f epatch >/dev/null ; then
@@ -43,6 +47,10 @@ try_to_apply_patches()
             fi
             touch "${_ap_rememberfile}" || die "Failed to touch ${_ap_rememberfile}!"
         done
+
+		# make sure nullglob is set to what it was before this function was called
+		[[ ${saved_opt} == no ]] && shopt -u nullglob
+
         if [[ -e ${_ap_rememberfile} ]]; then
             issue_a_warning "will be"
         else


### PR DESCRIPTION
...by using nullglob. In order to not screw with previous shopt
settings, we test whether nullglob was already active or not and
act accordingly.