### PR TITLE
Allow more epatch_user like patch directories, including SLOT

### DIFF
--- a/auto-patch/auto-patch.bash.in
+++ b/auto-patch/auto-patch.bash.in
@@ -15,8 +15,6 @@ PATCH_DIR="@PH_LOCALSTATEDIR@/db/paludis/autopatches"
 # Configuration override
 [[ -f ${CONFIG_FILE} ]] && source ${CONFIG_FILE}
 
-PATCH_DIR_FULL="${PATCH_DIR}/${HOOK}/${CATEGORY}/${PF}"
-
 _ap_rememberfile="${T}/.autopatch_was_here_${PALUDIS_PID}"
 
 issue_a_warning()
@@ -28,35 +26,35 @@ issue_a_warning()
 
 try_to_apply_patches()
 {
-    if [[ -n ${PALUDIS_HOOK_DEBUG} ]]; then
-        einfo "Check ${PATCH_DIR_FULL}"
-    fi
-    if [[ -d ${PATCH_DIR_FULL} ]] ; then
-		# activate nullglob if it isn't already
-		local saved_opt=$(shopt nullglob &> /dev/null && echo "yes" || echo "no")
-		[[ ${saved_opt} == no ]] && shopt -s nullglob
+	local check
+	for check in "${PATCH_DIR}/${HOOK}"/${CATEGORY}/{${P}-${PR},${P},${PN}}{,:${SLOT}}; do
+		if [[ -d ${check} ]] ; then
+			# activate nullglob if it isn't already
+			local saved_opt=$(shopt nullglob &> /dev/null && echo "yes" || echo "no")
+			[[ ${saved_opt} == no ]] && shopt -s nullglob
 
-        cd "${S}" || die "Failed to cd into ${S}!"
-        for i in "${PATCH_DIR_FULL}"/*.patch ; do
-            if declare -f epatch >/dev/null ; then
-                epatch ${i}
-            else
-                # sane default if no epatch is there
-                einfo "Applying ${i} ..."
-                patch -p1 -i "${i}" || die "Failed to apply ${i}!"
-            fi
-            touch "${_ap_rememberfile}" || die "Failed to touch ${_ap_rememberfile}!"
-        done
+			cd "${S}" || die "Failed to cd into ${S}!"
+			for i in "${check}"/*.patch ; do
+				if declare -f epatch >/dev/null ; then
+					epatch ${i}
+				else
+					# sane default if no epatch is there
+					einfo "Applying ${i} ..."
+					patch -p1 -i "${i}" || die "Failed to apply ${i}!"
+				fi
+				touch "${_ap_rememberfile}" || die "Failed to touch ${_ap_rememberfile}!"
+			done
 
-		# make sure nullglob is set to what it was before this function was called
-		[[ ${saved_opt} == no ]] && shopt -u nullglob
+			# make sure nullglob is set to what it was before this function was called
+			[[ ${saved_opt} == no ]] && shopt -u nullglob
 
-        if [[ -e ${_ap_rememberfile} ]]; then
-            issue_a_warning "will be"
-        else
-            einfo "No patches in for this package."
-        fi
-    fi
+			if [[ -e ${_ap_rememberfile} ]]; then
+				issue_a_warning "will be"
+			else
+				einfo "No patches in for this package."
+			fi
+		fi
+	done
 }
 
 case "${HOOK}" in


### PR DESCRIPTION
It is probably up to debate whether it is a good idea to use non-`${CATEGORY}/${PF}` directories, but I do and I'd rather leave that choice to the user.