### PR TITLE
Customizable installation && typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# vim:ts=4:expandtab:
 # "Build" script for my paludis-hooks package
 # Copyright 2012-2013 by Alex Turbov <i.zaufi@gmail.com>
 #
@@ -46,83 +47,93 @@ set(PH_HOOKSCONFDIR   "${PH_PALUDISCONFDIR}/hooks/configs")
 set(PH_PROFILEDIR     "${PH_SYSCONFDIR}/profile.d")
 set(PH_ENVDIR         "${PH_SYSCONFDIR}/env.d")
 # NOTE Hardcoded nowadays! Dunno is there any reason to detect it...
-set(PH_COMMANDSDIR    "/usr/libexec/cave/commands")
+#set(PH_COMMANDSDIR    "/usr/libexec/cave/commands")
+# The reason is: testing installation in temporary image dir for example
+set(PH_COMMANDSDIR    "${CMAKE_INSTALL_FULL_LIBEXECDIR}/cave/commands")
 
 # Autopatch hook
-configure_file(auto-patch/auto-patch.bash.in auto-patch/auto-patch.bash @ONLY)
-configure_file(auto-patch/auto-patch.conf.in auto-patch/auto-patch.conf @ONLY)
-install(
-    PROGRAMS ${CMAKE_BINARY_DIR}/auto-patch/auto-patch.bash
-    DESTINATION ${PH_DATAROOTDIR}
-  )
-install(
-    FILES ${CMAKE_BINARY_DIR}/auto-patch/auto-patch.conf
-    DESTINATION ${PH_HOOKSCONFDIR}
-  )
+if(WITH_AUTOPATCH)
+    configure_file(auto-patch/auto-patch.bash.in auto-patch/auto-patch.bash @ONLY)
+    configure_file(auto-patch/auto-patch.conf.in auto-patch/auto-patch.conf @ONLY)
+    install(
+        PROGRAMS ${CMAKE_BINARY_DIR}/auto-patch/auto-patch.bash
+        DESTINATION ${PH_DATAROOTDIR}
+        )
+    install(
+        FILES ${CMAKE_BINARY_DIR}/auto-patch/auto-patch.conf
+        DESTINATION ${PH_HOOKSCONFDIR}
+        )
+endif()
 
 # Filesystem manager hook
-set(FILESYSTEM_MANAGER_DTD "${PH_DATAROOTDIR}/filesystem-manager/filesystem-manager.dtd")
-set(FILESYSTEM_MANAGER_XSL "${PH_DATAROOTDIR}/filesystem-manager/filesystem-manager.xsl")
-configure_file(filesystem-manager/filesystem-manager.conf.in filesystem-manager/filesystem-manager.conf @ONLY)
-configure_file(filesystem-manager/filesystem-manager.bash.in filesystem-manager/filesystem-manager.bash @ONLY)
-install(
-    PROGRAMS ${CMAKE_BINARY_DIR}/filesystem-manager/filesystem-manager.bash
-    DESTINATION ${PH_DATAROOTDIR}
-  )
-install(
-    FILES ${CMAKE_BINARY_DIR}/filesystem-manager/filesystem-manager.conf
-    DESTINATION ${PH_HOOKSCONFDIR}
-  )
-install(
-    FILES filesystem-manager/filesystem-manager.xsl
-    DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
-  )
-install(
-    FILES filesystem-manager/filesystem-manager.dtd
-    DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
-  )
-install(
-    DIRECTORY filesystem-manager/commands
-    DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
-  )
+if(WITH_FS_MANAGER)
+    set(FILESYSTEM_MANAGER_DTD "${PH_DATAROOTDIR}/filesystem-manager/filesystem-manager.dtd")
+    set(FILESYSTEM_MANAGER_XSL "${PH_DATAROOTDIR}/filesystem-manager/filesystem-manager.xsl")
+    configure_file(filesystem-manager/filesystem-manager.conf.in filesystem-manager/filesystem-manager.conf @ONLY)
+    configure_file(filesystem-manager/filesystem-manager.bash.in filesystem-manager/filesystem-manager.bash @ONLY)
+    install(
+        PROGRAMS ${CMAKE_BINARY_DIR}/filesystem-manager/filesystem-manager.bash
+        DESTINATION ${PH_DATAROOTDIR}
+        )
+    install(
+        FILES ${CMAKE_BINARY_DIR}/filesystem-manager/filesystem-manager.conf
+        DESTINATION ${PH_HOOKSCONFDIR}
+        )
+    install(
+        FILES filesystem-manager/filesystem-manager.xsl
+        DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
+        )
+    install(
+        FILES filesystem-manager/filesystem-manager.dtd
+        DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
+        )
+    install(
+        DIRECTORY filesystem-manager/commands
+        DESTINATION ${PH_DATAROOTDIR}/filesystem-manager
+        )
+endif()
 
 # Package environment configurator
-configure_file(package.env/setup_pkg_env.bash.in package.env/setup_pkg_env.bash @ONLY)
-install(
-    FILES ${CMAKE_BINARY_DIR}/package.env/setup_pkg_env.bash
-    DESTINATION ${PH_LIBEXECDIR}
-  )
-install(
-    FILES
-        package.env/default-deps-trk.conf
-        package.env/default-silent-rules.conf
-        package.env/extra-optimize.conf
-        package.env/lto.conf
-        package.env/max-debug.conf
-        package.env/no-debug.conf
-        package.env/no-modern-c++.conf
-        package.env/no-gnu-tls.conf
-        package.env/no-gc-sections.conf
-        package.env/no-lto.conf
-        package.env/use-bfd-linker.conf
-        package.env/use-gold-linker.conf
-        package.env/use-latest-gcc.conf
-        package.env/use-modern-c++.conf
-    DESTINATION ${PH_PALUDISCONFDIR}/env.conf.d
-  )
+if(WITH_PACKAGE_ENV)
+    configure_file(package.env/setup_pkg_env.bash.in package.env/setup_pkg_env.bash @ONLY)
+    install(
+        FILES ${CMAKE_BINARY_DIR}/package.env/setup_pkg_env.bash
+        DESTINATION ${PH_LIBEXECDIR}
+      )
+    install(
+        FILES
+            package.env/default-deps-trk.conf
+            package.env/default-silent-rules.conf
+            package.env/extra-optimize.conf
+            package.env/lto.conf
+            package.env/max-debug.conf
+            package.env/no-debug.conf
+            package.env/no-modern-c++.conf
+            package.env/no-gnu-tls.conf
+            package.env/no-gc-sections.conf
+            package.env/no-lto.conf
+            package.env/use-bfd-linker.conf
+            package.env/use-gold-linker.conf
+            package.env/use-latest-gcc.conf
+            package.env/use-modern-c++.conf
+        DESTINATION ${PH_PALUDISCONFDIR}/env.conf.d
+      )
+endif()
 
 # In Memory Build hook
-configure_file(workdir-tmpfs/workdir-tmpfs.bash.in workdir-tmpfs/workdir-tmpfs.bash @ONLY)
-configure_file(workdir-tmpfs/workdir-tmpfs.conf.in workdir-tmpfs/workdir-tmpfs.conf @ONLY)
+if(WITH_WORKDIR_TMPFS)
+    configure_file(workdir-tmpfs/workdir-tmpfs.bash.in workdir-tmpfs/workdir-tmpfs.bash @ONLY)
+    configure_file(workdir-tmpfs/workdir-tmpfs.conf.in workdir-tmpfs/workdir-tmpfs.conf @ONLY)
 
-install(
-    PROGRAMS ${CMAKE_BINARY_DIR}/workdir-tmpfs/workdir-tmpfs.bash
-    DESTINATION ${PH_DATAROOTDIR}
-  )
-install(
-    FILES ${CMAKE_BINARY_DIR}/workdir-tmpfs/workdir-tmpfs.conf
-    DESTINATION ${PH_HOOKSCONFDIR}
-  )
+    install(
+        PROGRAMS ${CMAKE_BINARY_DIR}/workdir-tmpfs/workdir-tmpfs.bash
+        DESTINATION ${PH_DATAROOTDIR}
+      )
+    install(
+        FILES ${CMAKE_BINARY_DIR}/workdir-tmpfs/workdir-tmpfs.conf
+        DESTINATION ${PH_HOOKSCONFDIR}
+      )
+endif()
 
 # Some other helpers...
 install(

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 What is this?
 =============
 
-Here is a set of my hooks (plugins) for [plaudis](http://paludis.exherbo.org) I wrote and use few years already.
+Here is a set of my hooks (plugins) for [paludis](http://paludis.exherbo.org) I wrote and use few years already.
 
 Briefly this package consists of:
 * __Autopatch__ hook -- an easy way to apply patches ([here](https://github.com/zaufi/paludis-autopatches) is my set of patches)

--- a/package.env/setup_pkg_env.bash.in
+++ b/package.env/setup_pkg_env.bash.in
@@ -26,7 +26,7 @@ phenv-get-gcc-version()
 #
 phenv-get-cpu-available()
 {
-    grep -c ^processor /proc/cpuinfo
+    nproc
 }
 
 #BEGIN Helper functions named after toolchain-funcs.eclass

--- a/profile.d/cave-aliases.sh
+++ b/profile.d/cave-aliases.sh
@@ -17,7 +17,7 @@ alias world-up='cave resolve ${CAVE_RESUME_FILE_OPT} -c -km -Km -Cs -P "*/*" -Si
 alias system-up='cave resolve ${CAVE_RESUME_FILE_OPT} -c -km -Km -Cs -P "*/*" -Si -si -Rn system'
 
 #
-# Reuse cave bash completer to generate compltions for just introduced aliases
+# Reuse cave bash completer to generate completions for just introduced aliases
 #
 make_completion_wrapper _cave _cs cave search
 complete -o bashdefault -o default -F _cs cs

--- a/workdir-tmpfs/workdir-tmpfs.bash.in
+++ b/workdir-tmpfs/workdir-tmpfs.bash.in
@@ -107,7 +107,7 @@ try_prepare_workdir()
             return 0
         fi
     else
-        einfo "RAM usage stats for ${P} is not available. Will build the pacakge on disk this time..."
+        einfo "RAM usage stats for ${P} is not available. Will build the package on disk this time..."
         return 0
     fi
 


### PR DESCRIPTION
I've tried to add **-DWITH_SOMETHING** options to makefile so we can customize installation with USE flags in ebuild. I tested it with `USE="autopatch filesystem-manager -workdir-tmpfs -package.env"` and it worked as expected. 
Additionaly, there are a couple of small fixes, diff says all I think. 
Tell me please if I did something wrong. This was my first exp with cmake. 
